### PR TITLE
Let build run independent of previous steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Decrypt secrets
         run: git secret reveal -f
       - name: Build and test app
+        if: always()
         run: ./gradlew build
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
If git secrets is not available, the step should still be executed.