### PR TITLE
Add change.org sanitizer

### DIFF
--- a/app/src/main/kotlin/com/svenjacobs/app/leon/startup/ContainerInitializer.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/startup/ContainerInitializer.kt
@@ -25,6 +25,7 @@ import com.svenjacobs.app.leon.core.domain.sanitizer.amazon.AmazonProductSanitiz
 import com.svenjacobs.app.leon.core.domain.sanitizer.amazon.AmazonSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.amazon.AmazonSmileSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.aol.AolSearchSanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.change.ChangeSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.ebay.EbaySanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.emptyparameters.EmptyParametersSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.facebook.FacebookSanitizer
@@ -60,6 +61,7 @@ class ContainerInitializer : DistinctInitializer<Unit> {
 				AmazonSanitizer(),
 				AmazonSmileSanitizer(),
 				AolSearchSanitizer(),
+				ChangeSanitizer(),
 				EbaySanitizer(),
 				EmptyParametersSanitizer(),
 				FacebookSanitizer(),

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/change/ChangeSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/change/ChangeSanitizer.kt
@@ -1,0 +1,45 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2023 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.svenjacobs.app.leon.core.domain.sanitizer.change
+
+import android.content.Context
+import com.svenjacobs.app.leon.core.common.regex.RegexFactory
+import com.svenjacobs.app.leon.core.domain.R
+import com.svenjacobs.app.leon.core.domain.sanitizer.RegexSanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.Sanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
+
+class ChangeSanitizer : RegexSanitizer(
+	regex = RegexFactory.AllParameters,
+) {
+
+	override val id = SanitizerId("change")
+
+	override fun getMetadata(context: Context) = Sanitizer.Metadata(
+		name = context.getString(R.string.sanitizer_change_name),
+	)
+
+	override fun matchesDomain(input: String) = DOMAIN_REGEX.containsMatchIn(
+		input,
+	)
+
+	private companion object {
+		private val DOMAIN_REGEX = Regex("change\\.org.+")
+	}
+}

--- a/core-domain/src/main/res/values/strings.xml
+++ b/core-domain/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="sanitizer_amazon_product_name">Amazon Products</string>
     <string name="sanitizer_amazon_smile_name" translatable="false">Amazon Smile</string>
     <string name="sanitizer_aol_search_name">AOL Search</string>
+    <string name="sanitizer_change_name" translatable="false">Change</string>
     <string name="sanitizer_ebay_name" translatable="false">eBay</string>
     <string name="sanitizer_empty_parameters_name">Empty Parameters</string>
     <string name="sanitizer_facebook_name" translatable="false">Facebook</string>

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/change/ChangeSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/change/ChangeSanitizerTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2023 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.svenjacobs.app.leon.core.domain.sanitizer.change
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+class ChangeSanitizerTest : WordSpec(
+	{
+
+		"invoke" should {
+
+			"remove all parameters from Change petition URL" {
+				val sanitizer = ChangeSanitizer()
+				val result = sanitizer(
+                    "https://www.change.org/p/verbot-von-silvesterfeuerwerk-f%C3%BCr-privatpers"
+                        "onen-staedtetag-bmuv?utm_content=cl_sharecopy_12878233_de-DE%3Av3&recr" +
+                        "uiter=44645781&recruited_by_id=29ffed30-7385-0130-ec6e-3c764e044e9e&ut" +
+                        "m_source=share_petition&utm_medium=copylink&utm_campaign=psf_combo_sha" +
+                        "re_initial&pt=AVBldGl0aW9uAJmBxABBBBBAAAY7fdDHYupoE1NzU0NzE3Zg%3D%3D",
+				)
+
+				result shouldBe "https://www.change.org/p/verbot-von-silvesterfeuerwerk-f%C3%BC" +
+                    "r-privatpersonen-staedtetag-bmuv"
+			}
+		}
+	},
+)

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/change/ChangeSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/change/ChangeSanitizerTest.kt
@@ -29,15 +29,15 @@ class ChangeSanitizerTest : WordSpec(
 			"remove all parameters from Change petition URL" {
 				val sanitizer = ChangeSanitizer()
 				val result = sanitizer(
-                    "https://www.change.org/p/verbot-von-silvesterfeuerwerk-f%C3%BCr-privatpers" +
-                        "onen-staedtetag-bmuv?utm_content=cl_sharecopy_12878233_de-DE%3Av3&recr" +
-                        "uiter=44645781&recruited_by_id=29ffed30-7385-0130-ec6e-3c764e044e9e&ut" +
-                        "m_source=share_petition&utm_medium=copylink&utm_campaign=psf_combo_sha" +
-                        "re_initial&pt=AVBldGl0aW9uAJmBxABBBBBAAAY7fdDHYupoE1NzU0NzE3Zg%3D%3D",
+					"https://www.change.org/p/verbot-von-silvesterfeuerwerk-f%C3%BCr-privatpers" +
+						"onen-staedtetag-bmuv?utm_content=cl_sharecopy_12878233_de-DE%3Av3&recr" +
+						"uiter=44645781&recruited_by_id=29ffed30-7385-0130-ec6e-3c764e044e9e&ut" +
+						"m_source=share_petition&utm_medium=copylink&utm_campaign=psf_combo_sha" +
+						"re_initial&pt=AVBldGl0aW9uAJmBxABBBBBAAAY7fdDHYupoE1NzU0NzE3Zg%3D%3D",
 				)
 
 				result shouldBe "https://www.change.org/p/verbot-von-silvesterfeuerwerk-f%C3%BC" +
-                    "r-privatpersonen-staedtetag-bmuv"
+					"r-privatpersonen-staedtetag-bmuv"
 			}
 		}
 	},

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/change/ChangeSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/change/ChangeSanitizerTest.kt
@@ -29,7 +29,7 @@ class ChangeSanitizerTest : WordSpec(
 			"remove all parameters from Change petition URL" {
 				val sanitizer = ChangeSanitizer()
 				val result = sanitizer(
-                    "https://www.change.org/p/verbot-von-silvesterfeuerwerk-f%C3%BCr-privatpers"
+                    "https://www.change.org/p/verbot-von-silvesterfeuerwerk-f%C3%BCr-privatpers" +
                         "onen-staedtetag-bmuv?utm_content=cl_sharecopy_12878233_de-DE%3Av3&recr" +
                         "uiter=44645781&recruited_by_id=29ffed30-7385-0130-ec6e-3c764e044e9e&ut" +
                         "m_source=share_petition&utm_medium=copylink&utm_campaign=psf_combo_sha" +


### PR DESCRIPTION
This sanitizer cleans change.org petition share links which contain tracking like recruiter ids. It does not work on shortened links (chng.it) but on long urls.

- [x]  Automated test
- [x]  Resource translations
- [x]  Plugging the sanitizer into ContainerInitializer.kt
- [x]  Testing it really