### PR TITLE
Feature/159 jdoqocy redirect sanitizer

### DIFF
--- a/app/src/main/kotlin/com/svenjacobs/app/leon/startup/ContainerInitializer.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/startup/ContainerInitializer.kt
@@ -34,6 +34,7 @@ import com.svenjacobs.app.leon.core.domain.sanitizer.google.GoogleAdsSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.google.GoogleAnalyticsSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.google.GoogleSearchSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.instagram.InstagramSanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.jdoqocy.JdoqocyRedirectSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.linksynergy.LinkSynergySanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.netflix.NetflixSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.newegg.NewEggSanitizer
@@ -82,6 +83,7 @@ class ContainerInitializer : DistinctInitializer<Unit> {
 				YoutubeMusicSanitizer(),
 				YoutubeRedirectSanitizer(),
 				YoutubeShortUrlSanitizer(),
+				JdoqocyRedirectSanitizer()
 			),
 		)
 	}

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/jdoqocy/JdoqocyRedirectSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/jdoqocy/JdoqocyRedirectSanitizer.kt
@@ -1,0 +1,25 @@
+package com.svenjacobs.app.leon.core.domain.sanitizer.jdoqocy
+
+import android.content.Context
+import com.svenjacobs.app.leon.core.common.regex.RegexFactory
+import com.svenjacobs.app.leon.core.domain.sanitizer.Sanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
+import com.svenjacobs.app.leon.core.domain.R
+import com.svenjacobs.app.leon.core.domain.sanitizer.SearchResultSanitizer
+
+class JdoqocyRedirectSanitizer : SearchResultSanitizer(
+	RegexFactory.ofParameter("url"),
+) {
+
+	override val id = SanitizerId("jdoqocy")
+
+	override fun getMetadata(context: Context) = Sanitizer.Metadata(
+		name = context.getString(R.string.sanitizer_jdoqocy_redirect_name),
+	)
+
+	override fun matchesDomain(input: String) = DOMAIN_REGEX.containsMatchIn(input)
+
+	private companion object {
+		private val DOMAIN_REGEX = Regex("jdoqocy\\.com/click")
+	}
+}

--- a/core-domain/src/main/res/values-de/strings.xml
+++ b/core-domain/src/main/res/values-de/strings.xml
@@ -23,4 +23,5 @@
     <string name="sanitizer_google_search_name">Google Suche</string>
     <string name="sanitizer_yahoo_search_name">Yahoo Suche</string>
     <string name="sanitizer_youtube_redirect_name">YouTube Weiterleitung</string>
+    <string name="sanitizer_jdoqocy_redirect_name">Jdoqocy Weiterleitung</string>
 </resources>

--- a/core-domain/src/main/res/values-ru/strings.xml
+++ b/core-domain/src/main/res/values-ru/strings.xml
@@ -23,4 +23,5 @@
     <string name="sanitizer_google_search_name">Google Search</string> <!-- TODO: translate -->
     <string name="sanitizer_yahoo_search_name">Yahoo Search</string> <!-- TODO: translate -->
     <string name="sanitizer_youtube_redirect_name">YouTube Redirect</string> <!-- TODO: translate -->
+    <string name="sanitizer_jdoqocy_redirect_name">Jdoqocy Redirect</string> <!-- TODO: translate -->
 </resources>

--- a/core-domain/src/main/res/values/strings.xml
+++ b/core-domain/src/main/res/values/strings.xml
@@ -43,4 +43,5 @@
     <string name="sanitizer_youtube_redirect_name">YouTube Redirect</string>
     <string name="sanitizer_youtube_short_url_name" translatable="false">Youtu.be</string>
     <string name="sanitizer_youtube_music_name" translatable="false">YouTube Music</string>
+    <string name="sanitizer_jdoqocy_redirect_name">Jdoqocy Redirect</string>
 </resources>

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/jdoqocy/JdoqocyRedirectSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/jdoqocy/JdoqocyRedirectSanitizerTest.kt
@@ -1,0 +1,21 @@
+package com.svenjacobs.app.leon.core.domain.sanitizer.jdoqocy
+
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.WordSpec
+
+class JdoqocyRedirectSanitizerTest : WordSpec(
+	{
+
+		"invoke" should {
+
+			"extract URL from Jdoqocy redirect link" {
+				val sanitizer = JdoqocyRedirectSanitizer()
+				val result = sanitizer(
+					"https://www.jdoqocy.com/click-7988170-15232592?SID=11003b6m4t07&url=https%3A%2F%2Fwww.gog.com%2Fde%2Fgame%2Falwas_awakening",
+				)
+
+				result shouldBe "https://www.gog.com/de/game/alwas_awakening"
+			}
+		}
+	},
+)


### PR DESCRIPTION
Issue: #159 

This pull request adds a new class called JdoqocyRedirectSanitizer to the project, which extends the SearchResultSanitizer abstract class. The JdoqocyRedirectSanitizer is used to sanitize URLs that contain a Jdoqocy redirect tracker, such as https://www.jdoqocy.com/click-7988170-15232592?SID=11003b6m4t07&url=https%3A%2F%2Fwww.gog.com%2Fde%2Fgame%2Falwas_awakening.

The JdoqocyRedirectSanitizer class extracts the encoded URL from the query parameter url and decodes it using URLDecoder. The resulting URL is then returned as the sanitized output.

This pull request also includes a unit test for the JdoqocyRedirectSanitizer class to ensure its correctness.

Overall, this contribution should help improve the project's URL sanitization capabilities and provide a more robust solution for handling URLs containing Jdoqocy redirect trackers.