### PR TITLE
Elfinanciero sanitizer

### DIFF
--- a/app/src/main/kotlin/com/svenjacobs/app/leon/startup/ContainerInitializer.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/startup/ContainerInitializer.kt
@@ -26,6 +26,7 @@ import com.svenjacobs.app.leon.core.domain.sanitizer.amazon.AmazonSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.aol.AolSearchSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.change.ChangeSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.ebay.EbaySanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.elfinanciero.ElFinancieroSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.emptyparameters.EmptyParametersSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.facebook.FacebookSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.flipkart.FlipkartSanitizer
@@ -84,6 +85,7 @@ class ContainerInitializer : DistinctInitializer<Unit> {
 				YoutubeRedirectSanitizer(),
 				YoutubeShortUrlSanitizer(),
 				JdoqocySanitizer(),
+				ElFinancieroSanitizer(),
 			),
 		)
 	}

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/elfinanciero/ElFinancieroSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/elfinanciero/ElFinancieroSanitizer.kt
@@ -1,0 +1,19 @@
+package com.svenjacobs.app.leon.core.domain.sanitizer.elfinanciero
+
+import android.content.Context
+import com.svenjacobs.app.leon.core.common.regex.RegexFactory
+import com.svenjacobs.app.leon.core.domain.R
+import com.svenjacobs.app.leon.core.domain.sanitizer.RegexSanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.Sanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
+
+class ElFinancieroSanitizer : RegexSanitizer(
+	regex = RegexFactory.ofWildcardParameter("outputType"),
+) {
+
+	override val id = SanitizerId("elfinanciero")
+
+	override fun getMetadata(context: Context) = Sanitizer.Metadata(
+		name = context.getString(R.string.sanitizer_elfinanciero_name),
+	)
+}

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/elfinanciero/ElFinancieroSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/elfinanciero/ElFinancieroSanitizer.kt
@@ -8,7 +8,7 @@ import com.svenjacobs.app.leon.core.domain.sanitizer.Sanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
 
 class ElFinancieroSanitizer : RegexSanitizer(
-	regex = RegexFactory.ofWildcardParameter("outputType"),
+	regex = RegexFactory.ofParameter("outputType"),
 ) {
 
 	override val id = SanitizerId("elfinanciero")

--- a/core-domain/src/main/res/values/strings.xml
+++ b/core-domain/src/main/res/values/strings.xml
@@ -44,4 +44,5 @@
     <string name="sanitizer_youtube_short_url_name" translatable="false">Youtu.be</string>
     <string name="sanitizer_youtube_music_name" translatable="false">YouTube Music</string>
     <string name="sanitizer_jdoqocy_name" translatable="false">Jdoqocy</string>
+    <string name="sanitizer_elfinanciero_name" translatable="false">ElFinanciero</string>
 </resources>

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/elfinanciero/ElFinancieroSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/elfinanciero/ElFinancieroSanitizerTest.kt
@@ -10,12 +10,13 @@ class ElFinancieroSanitizerTest : WordSpec(
 				val sanitizer = ElFinancieroSanitizer()
 
 				val result = sanitizer(
-					"https://www.elfinanciero.com.mx/food-and-drink/2023/01/04/dia-de-reyes-2023-donde-comprar-rosca-de-tacos-en-la-cdmx/?outputType=amp",
+					"https://www.elfinanciero.com.mx/food-and-drink/2023/01/04/" +
+						"dia-de-reyes-2023-donde-comprar-rosca-de-tacos-en-la-cdmx/?outputType=amp",
 				)
 
-				result shouldBe "https://www.elfinanciero.com.mx/food-and-drink/2023/01/04/dia-de-reyes-2023-donde-comprar-rosca-de-tacos-en-la-cdmx/"
+				result shouldBe "https://www.elfinanciero.com.mx/food-and-drink/2023/01/04/" +
+					"dia-de-reyes-2023-donde-comprar-rosca-de-tacos-en-la-cdmx/"
 			}
 		}
 	},
 )
-

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/elfinanciero/ElFinancieroSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/elfinanciero/ElFinancieroSanitizerTest.kt
@@ -1,0 +1,21 @@
+package com.svenjacobs.app.leon.core.domain.sanitizer.elfinanciero
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+class ElFinancieroSanitizerTest : WordSpec(
+	{
+		"invoke" should {
+			"remove \"outputType\" parameter" {
+				val sanitizer = ElFinancieroSanitizer()
+
+				val result = sanitizer(
+					"https://www.elfinanciero.com.mx/food-and-drink/2023/01/04/dia-de-reyes-2023-donde-comprar-rosca-de-tacos-en-la-cdmx/?outputType=amp",
+				)
+
+				result shouldBe "https://www.elfinanciero.com.mx/food-and-drink/2023/01/04/dia-de-reyes-2023-donde-comprar-rosca-de-tacos-en-la-cdmx/"
+			}
+		}
+	},
+)
+


### PR DESCRIPTION
Closes #150
 
Added ElFinancieroSanitizer class that extends the RegexSanitizer class. This sanitizer removes the outputType parameter from the URL of any El Financiero website result.