### PR TITLE
feat: Replace "Verify" by "Open" functionality

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,7 +142,6 @@ dependencies {
 	implementation(libs.androidx.lifecycle.viewmodel.ktx)
 	implementation(libs.androidx.datastore.preferences)
 	implementation(libs.kotlinx.coroutines.android)
-	implementation(libs.androidx.browser)
 	implementation(libs.jakewharton.timber)
 
 	debugImplementation(libs.facebook.stetho)

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/MainActivity.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/MainActivity.kt
@@ -18,13 +18,10 @@
 
 package com.svenjacobs.app.leon
 
-import android.content.ComponentName
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.browser.customtabs.CustomTabsClient
-import androidx.browser.customtabs.CustomTabsServiceConnection
 import androidx.compose.runtime.mutableStateOf
 import androidx.core.view.WindowCompat
 import com.svenjacobs.app.leon.ui.MainRouter
@@ -45,11 +42,6 @@ class MainActivity : ComponentActivity() {
 				sourceText = sourceText,
 			)
 		}
-	}
-
-	override fun onStart() {
-		super.onStart()
-		warmupCustomTabsService()
 	}
 
 	override fun onNewIntent(intent: Intent?) {
@@ -83,21 +75,7 @@ class MainActivity : ComponentActivity() {
 		sourceText.value = text
 	}
 
-	private fun warmupCustomTabsService() {
-		val connection = object : CustomTabsServiceConnection() {
-			override fun onCustomTabsServiceConnected(name: ComponentName, client: CustomTabsClient) {
-				client.warmup(0)
-			}
-
-			override fun onServiceDisconnected(name: ComponentName?) {
-			}
-		}
-
-		CustomTabsClient.bindCustomTabsService(this, CHROME_PACKAGE_NAME, connection)
-	}
-
 	private companion object {
 		private const val MIME_TYPE_TEXT_PLAIN = "text/plain"
-		private const val CHROME_PACKAGE_NAME = "com.android.chrome"
 	}
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -21,7 +21,7 @@
     <string name="screen_settings">Einstellungen</string>
     <string name="scaffold_title">Léon – Der URL Cleaner</string>
     <string name="share">Teilen</string>
-    <string name="verify">Überprüfen</string>
+    <string name="open">Öffnen</string>
     <string name="copy">Kopieren</string>
     <string name="clipboard_message">Link in Zwischenablage kopiert</string>
     <string name="how_to_title">Anleitung</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -21,7 +21,7 @@
     <string name="screen_settings">Ustawienia</string>
     <string name="scaffold_title">Léon – Oczyszczacz URL</string>
     <string name="share">Udostępnij</string>
-    <string name="verify">Weryfikuj</string>
+    <string name="open">Open</string>> <!-- TODO: translate -->
     <string name="copy">Kopiuj</string>
     <string name="clipboard_message">Link skopiowany do schowka</string>
     <string name="how_to_title">Jak wykonać</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -21,7 +21,7 @@
     <string name="screen_settings">Настройки</string>
     <string name="scaffold_title">Léon – The URL Cleaner</string>
     <string name="share">Поделиться</string>
-    <string name="verify">Проверить</string>
+    <string name="open">Open</string>> <!-- TODO: translate -->
     <string name="copy">Копировать</string>
     <string name="clipboard_message">Ссылка скопирована в буфер обмена</string>
     <string name="how_to_title">Инструкция</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,7 +22,7 @@
     <string name="screen_settings">Settings</string>
     <string name="scaffold_title">Léon – The URL Cleaner</string>
     <string name="share">Share</string>
-    <string name="verify">Verify</string>
+    <string name="open">Open</string>
     <string name="copy">Copy</string>
     <string name="clipboard_message">Link copied to clipboard</string>
     <string name="how_to_title">How-to</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,6 @@ android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }
 androidx-appcompat = "androidx.appcompat:appcompat:1.6.1"
-androidx-browser = "androidx.browser:browser:1.5.0"
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidx-compose-bom" }
 androidx-compose-material2 = { module = "androidx.compose.material:material" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }


### PR DESCRIPTION
This PR replaces the "Verify" button, which was using Chrome Custom Tabs, with an "Open" button.

The open button sends an intent with the first URL of the cleaned result, which will be handled by the default app registered for this type of URL.

Closes #152 