### PR TITLE
fix: Use M3 version of ExposedDropdownMenu

### DIFF
--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/screens/settings/SettingsScreen.kt
@@ -24,16 +24,15 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ExposedDropdownMenuDefaults
-import androidx.compose.material.TextField
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -42,7 +41,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -51,6 +49,7 @@ import com.svenjacobs.app.leon.R
 import com.svenjacobs.app.leon.core.domain.action.ActionAfterClean
 import com.svenjacobs.app.leon.ui.screens.settings.model.SettingsScreenViewModel
 import com.svenjacobs.app.leon.ui.theme.AppTheme
+import com.svenjacobs.app.leon.ui.tooling.DayNightPreviews
 
 @Composable
 fun SettingsScreen(
@@ -74,7 +73,6 @@ fun SettingsScreen(
 }
 
 @Composable
-@OptIn(ExperimentalMaterialApi::class)
 private fun Content(
 	isLoading: Boolean,
 	browserEnabled: Boolean,
@@ -211,7 +209,7 @@ private fun ActionAfterClean.text(): String = when (this) {
 }
 
 @Composable
-@Preview(showBackground = true)
+@DayNightPreviews
 private fun ContentPreview() {
 	AppTheme {
 		Content(

--- a/app/src/main/kotlin/com/svenjacobs/app/leon/ui/tooling/DayNightPreviews.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/ui/tooling/DayNightPreviews.kt
@@ -1,0 +1,34 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2023 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.svenjacobs.app.leon.ui.tooling
+
+import android.content.res.Configuration
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+	name = "Day",
+	showBackground = true,
+)
+@Preview(
+	name = "Night",
+	uiMode = Configuration.UI_MODE_NIGHT_YES or Configuration.UI_MODE_TYPE_NORMAL,
+	showBackground = true,
+	backgroundColor = 0xFF000000,
+)
+annotation class DayNightPreviews


### PR DESCRIPTION
Oops, I accidentally used the Material 2 version of the `ExposedDropdownMenu`.

Closes #182 