### PR TITLE
Clean Google Click ID (gclid) from urls

### DIFF
--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/google/GoogleAnalyticsSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/google/GoogleAnalyticsSanitizer.kt
@@ -26,7 +26,7 @@ import com.svenjacobs.app.leon.core.domain.sanitizer.Sanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
 
 class GoogleAnalyticsSanitizer : RegexSanitizer(
-	regex = RegexFactory.ofWildcardParameter("ga_|utm_"),
+	regex = RegexFactory.ofWildcardParameter("ga_|utm_|gclid"),
 ) {
 
 	override val id = SanitizerId("google_analytics")

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/google/GoogleAnalyticsSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/google/GoogleAnalyticsSanitizerTest.kt
@@ -26,11 +26,11 @@ class GoogleAnalyticsSanitizerTest : WordSpec(
 
 		"invoke" should {
 
-			"remove \"ga_*\" and \"utm_*\" parameters" {
+			"remove \"ga_*\", \"utm_*\", and "gclid" parameters" {
 				val sanitizer = GoogleAnalyticsSanitizer()
 
 				val result = sanitizer(
-					"https://www.example.com?ga_abc=123&utm_def=456",
+					"https://www.example.com?ga_abc=123&utm_def=456&gclid=789",
 				)
 
 				result shouldBe "https://www.example.com"

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/google/GoogleAnalyticsSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/google/GoogleAnalyticsSanitizerTest.kt
@@ -26,7 +26,7 @@ class GoogleAnalyticsSanitizerTest : WordSpec(
 
 		"invoke" should {
 
-			"remove \"ga_*\", \"utm_*\", and "gclid" parameters" {
+			"remove \"ga_*\", \"utm_*\", and \"gclid\" parameters" {
 				val sanitizer = GoogleAnalyticsSanitizer()
 
 				val result = sanitizer(


### PR DESCRIPTION
Fixes #190 

Added a test case and the removal.