### PR TITLE
feat: Add sanitizer for tiktok

### DIFF
--- a/app/src/main/kotlin/com/svenjacobs/app/leon/startup/ContainerInitializer.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/startup/ContainerInitializer.kt
@@ -55,6 +55,7 @@ import com.svenjacobs.app.leon.core.domain.sanitizer.spiegel.SpiegelSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.spotify.SpotifySanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.theguardian.TheGuardianSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.threads.ThreadsSanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.tiktok.TiktokSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.webtrekk.WebtrekkSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.x.XSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.yahoo.YahooSearchSanitizer
@@ -108,6 +109,7 @@ class ContainerInitializer : DistinctInitializer<Unit> {
 				SpotifySanitizer(),
 				TheGuardianSanitizer(),
 				ThreadsSanitizer(),
+				TiktokSanitizer(),
 				WebtrekkSanitizer(),
 				XSanitizer(),
 				YahooSearchSanitizer(),

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/tiktok/TiktokSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/tiktok/TiktokSanitizer.kt
@@ -1,0 +1,43 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2023 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.svenjacobs.app.leon.core.domain.sanitizer.tiktok
+
+import android.content.Context
+import com.svenjacobs.app.leon.core.common.domain.matchesDomain
+import com.svenjacobs.app.leon.core.common.regex.RegexFactory
+import com.svenjacobs.app.leon.core.domain.R
+import com.svenjacobs.app.leon.core.domain.sanitizer.RegexSanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.Sanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
+
+class TiktokSanitizer :
+	RegexSanitizer(
+		regex = RegexFactory.AllParameters,
+	) {
+
+	override val id = SanitizerId("tiktok")
+
+	override fun getMetadata(context: Context) = Sanitizer.Metadata(
+		name = context.getString(R.string.sanitizer_tiktok_name),
+	)
+
+	override fun matchesDomain(input: String) = input.matchesDomain(
+		domain = "tiktok.com",
+	)
+}

--- a/core-domain/src/main/res/values/strings.xml
+++ b/core-domain/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
     <string name="sanitizer_spotify_name" translatable="false">Spotify</string>
     <string name="sanitizer_theguardian" translatable="false">The Guardian</string>
     <string name="sanitizer_threads" translatable="false">Threads.net</string>
+    <string name="sanitizer_tiktok_name" translatable="false">TikTok</string>
     <string name="sanitizer_webtrekk_name" translatable="false">Webtrekk</string>
     <string name="sanitizer_x_name" translatable="false">X (Twitter)</string>
     <string name="sanitizer_yahoo_search_name">Yahoo Search</string>

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/tiktok/TiktokSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/tiktok/TiktokSanitizerTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2023 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.svenjacobs.app.leon.core.domain.sanitizer.tiktok
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+class TiktokSanitizerTest :
+	WordSpec(
+		{
+			val sanitizer = TiktokSanitizer()
+
+			"invoke" should {
+
+				"remove all parameters" {
+					var result = sanitizer(
+						"https://www.tiktok.com/@lihayk/video/7271645505522879751?" +
+							"is_from_webapp=1&sender_device=pc&web_id=7098566637619288452",
+					)
+
+					result shouldBe "https://www.tiktok.com/@lihayk/video/7271645505522879751"
+
+					result =
+						sanitizer(
+							"https://www.tiktok.com/@conqressesquotes/video/7284563007244389664" +
+								"?_t=3tmYqC7L494&_r=1",
+						)
+
+					result shouldBe "https://www.tiktok.com/@conqressesquotes/video/7284563007244389664"
+
+					result = sanitizer("https://www.tiktok.com/@elaine_carroll?_t=8gneIBdmRJ1&_r=1")
+
+					result shouldBe "https://www.tiktok.com/@elaine_carroll"
+				}
+			}
+
+			"matchesDomain" should {
+
+				"match tiktok.com" {
+					sanitizer.matchesDomain("https://tiktok.com") shouldBe true
+				}
+
+				"match www.tiktok.com" {
+					sanitizer.matchesDomain("https://www.tiktok.com") shouldBe true
+				}
+			}
+		},
+	)


### PR DESCRIPTION
Note some sharing interfaces in the app give you shortened links (like https://vt.tiktok.com/fr54gr6rf3e) that expand to the links matched here, but there isn't infrastructure in the app currently to deal with them.