### PR TITLE
fix: don't crash if no custom tabs client was found

### DIFF
--- a/app/src/main/kotlin/com/svenjacobs/app/leon/MainActivity.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/MainActivity.kt
@@ -105,7 +105,9 @@ class MainActivity : ComponentActivity() {
 		}
 
 		val packageName = CustomTabsClient.getPackageName(this, null)
-		CustomTabsClient.bindCustomTabsService(this, packageName, connection)
+		if (packageName != null) {
+			CustomTabsClient.bindCustomTabsService(this, packageName, connection)
+		}
 
 		customTabsInitialized = true
 	}


### PR DESCRIPTION
Fixes #422