### PR TITLE
Facebook Analytics Sanitizer: also remove sfnsn parameter

### DIFF
--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/facebook/FacebookAnalyticsSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/facebook/FacebookAnalyticsSanitizer.kt
@@ -27,7 +27,7 @@ import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
 
 class FacebookAnalyticsSanitizer :
 	RegexSanitizer(
-		regex = RegexFactory.ofWildcardParameter("fb_|fbclid"),
+		regex = RegexFactory.ofWildcardParameter("fb_|fbclid|sfnsn"),
 	) {
 
 	override val id = SanitizerId("facebook")

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/facebook/FacebookAnalyticsSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/facebook/FacebookAnalyticsSanitizerTest.kt
@@ -31,7 +31,7 @@ class FacebookAnalyticsSanitizerTest :
 					val sanitizer = FacebookAnalyticsSanitizer()
 
 					val result = sanitizer(
-						"https://www.example.com?fb_abc=123&fbclid=12345",
+						"https://www.example.com?fb_abc=123&fbclid=12345&sfnsn=scwspmo",
 					)
 
 					result shouldBe "https://www.example.com"


### PR DESCRIPTION
URLs opened from the Facbook app almost always also contain a `sfnsn` URL parameter; I typically see it with a value of `scwspmo`. It does not appear to be used for individual tracking, but rather to signify that it was shared from the FB app at all in the first place - possibly similar to `feature=shared` with YouTube.

Having this parameter in the URL reduces its immediate usefulness for sites like https://archive.today/, requiring a manual edit.

This PR is the result of me fixing this nag for myself / on my device; and if it's deemed useful, everyone else is more than welcome to it.