### PR TITLE
Add Salesforce sanitizer, covers #302

### DIFF
--- a/app/src/main/kotlin/com/svenjacobs/app/leon/startup/ContainerInitializer.kt
+++ b/app/src/main/kotlin/com/svenjacobs/app/leon/startup/ContainerInitializer.kt
@@ -51,6 +51,7 @@ import com.svenjacobs.app.leon.core.domain.sanitizer.pearl.PearlSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.reddit.RedditMailSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.reddit.RedditOutSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.reddit.RedditSanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.salesforce.SalesforceParametersSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.sessionids.SessionIdsSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.shopee.ShopeeSanitizer
 import com.svenjacobs.app.leon.core.domain.sanitizer.spiegel.SpiegelSanitizer
@@ -108,6 +109,7 @@ class ContainerInitializer : DistinctInitializer<Unit> {
 				RedditMailSanitizer(),
 				RedditOutSanitizer(),
 				RedditSanitizer(),
+				SalesforceParametersSanitizer(),
 				SessionIdsSanitizer(),
 				ShopeeSanitizer(),
 				SpiegelSanitizer(),

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/salesforce/SalesforceParametersSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/salesforce/SalesforceParametersSanitizer.kt
@@ -28,10 +28,7 @@ import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
 class SalesforceParametersSanitizer :
 	RegexSanitizer(
 		// see https://help.salesforce.com/s/articleView?id=sf.mc_gai_utm_parameters.htm&type=5
-		RegexFactory.ofParameter(
-			"utm_source|utm_medium|utm_campaign|utm_term|utm_content|utm_id|" +
-				"sfmc_id|sfmc_activityid",
-		),
+		RegexFactory.ofWildcardParameter("utm_|sfmc_"),
 	) {
 
 	override val id = SanitizerId("salesforce")

--- a/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/salesforce/SalesforceParametersSanitizer.kt
+++ b/core-domain/src/main/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/salesforce/SalesforceParametersSanitizer.kt
@@ -1,0 +1,42 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2024 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.svenjacobs.app.leon.core.domain.sanitizer.salesforce
+
+import android.content.Context
+import com.svenjacobs.app.leon.core.common.regex.RegexFactory
+import com.svenjacobs.app.leon.core.domain.R
+import com.svenjacobs.app.leon.core.domain.sanitizer.RegexSanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.Sanitizer
+import com.svenjacobs.app.leon.core.domain.sanitizer.SanitizerId
+
+class SalesforceParametersSanitizer :
+	RegexSanitizer(
+		// see https://help.salesforce.com/s/articleView?id=sf.mc_gai_utm_parameters.htm&type=5
+		RegexFactory.ofParameter(
+			"utm_source|utm_medium|utm_campaign|utm_term|utm_content|utm_id|" +
+				"sfmc_id|sfmc_activityid",
+		),
+	) {
+
+	override val id = SanitizerId("salesforce")
+
+	override fun getMetadata(context: Context) = Sanitizer.Metadata(
+		name = context.getString(R.string.sanitizer_salesforce_name),
+	)
+}

--- a/core-domain/src/main/res/values/strings.xml
+++ b/core-domain/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="sanitizer_reddit" translatable="false">Reddit</string>
     <string name="sanitizer_reddit_mail" translatable="false">Reddit (click.redditmail.com)</string>
     <string name="sanitizer_reddit_out" translatable="false">Reddit (out.reddit.com)</string>
+    <string name="sanitizer_salesforce_name" translatable="false">Salesforce</string>
     <string name="sanitizer_session_ids_name" translatable="false">Session IDs</string>
     <string name="sanitizer_shopee" translatable="false">Shopee</string>
     <string name="sanitizer_spiegel_name" translatable="false">Spiegel</string>

--- a/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/salesforce/SalesforceParametersSanitizerTest.kt
+++ b/core-domain/src/test/kotlin/com/svenjacobs/app/leon/core/domain/sanitizer/salesforce/SalesforceParametersSanitizerTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Léon - The URL Cleaner
+ * Copyright (C) 2024 Sven Jacobs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.svenjacobs.app.leon.core.domain.sanitizer.salesforce
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+class SalesforceParametersSanitizerTest :
+	WordSpec(
+		{
+			val sanitizer = SalesforceParametersSanitizer()
+
+			"invoke" should {
+
+				"remove sfmc_activityid parameter as per #302" {
+					sanitizer(
+						"https://www.geox.com/it-IT/uomo/scarpe/stivaletti/?sfmc_activityid=a5542c58-11be-4f33-8dd5-5e0ebeae30f2",
+					) shouldBe "https://www.geox.com/it-IT/uomo/scarpe/stivaletti/"
+				}
+			}
+		},
+	)


### PR DESCRIPTION
Add a sanitizer for all Salesforce URL parameter values, as per https://help.salesforce.com/s/articleView?id=sf.mc_gai_utm_parameters.htm&type=5

This resolves #302 

Implementation is mostly 'blind', but it's an everyday use case of mine and I'll keep an eye on it.