### PR TITLE
fix: Leon as browser not working

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,7 +75,6 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:host="*" />
                 <data android:scheme="http" />
                 <data android:scheme="https" />
             </intent-filter>


### PR DESCRIPTION
AGP 8.7.0 (#476) introduced a [lint false positive](https://issuetracker.google.com/issues/365376495) which claimed "At least one host must be specified". That's why I added the `<data android:host="*" />` element, which however is wrong and breaks the browser functionality of Leon. This false positive was fixed in AGP 8.7.1.

Fixes #494 